### PR TITLE
Paging support for CPAT category

### DIFF
--- a/pages/categories/cpat/index.js
+++ b/pages/categories/cpat/index.js
@@ -1,20 +1,26 @@
 import Link from 'next/link';
-import Date from '../../components/date';
-import { getCategoryPosts } from '../../lib/posts';
-import utilStyles from '../../styles/utils.module.css';
+import Date from '../../../components/date';
+import { getCategoryPosts } from '../../../lib/posts';
+import utilStyles from '../../../styles/utils.module.css';
+import config from '../../../blogConfig';
 
 export async function getStaticProps() {
     const posts = getCategoryPosts('cpat');
-    console.log(posts);
+    const startIdx = 0;
+    const endIdx = config.postsPerPage;
+    const prevPosts = null;
+    const nextPosts = (endIdx >= posts.length) ? null : 2;
 
     return {
         props: {
-            posts
+            posts: posts.slice(startIdx, endIdx),
+            prevPosts,
+            nextPosts
         }
     }
 };
 
-export default function Cpat({ posts }) {
+export default function Cpat({ posts, prevPosts, nextPosts }) {
     return (
         <div>
             <h1>Category: CPAT</h1>
@@ -33,6 +39,16 @@ export default function Cpat({ posts }) {
                     ))
                 ) : ''}
             </ul>
+            {prevPosts !== null && (
+                <Link href={"/categories/cpat/pages/" + prevPosts} passHref>
+                    <a>« see newer posts</a>
+                </Link>
+            )}
+            {nextPosts !== null && (
+                <Link href={"/categories/cpat/pages/" + nextPosts} passHref>
+                <a>see older posts »</a>
+                </Link>
+            )}
         </div>
     );
 };

--- a/pages/categories/cpat/pages/[page].js
+++ b/pages/categories/cpat/pages/[page].js
@@ -1,0 +1,84 @@
+import Layout from '../../../../components/layout';
+import Link from 'next/link';
+import utilStyles from '../../../../styles/utils.module.css';
+import { getCategoryPosts } from '../../../../lib/posts';
+import config from '../../../../blogConfig';
+
+/**
+ * 
+ * @param {*} param0 
+ */
+export async function getStaticProps({ params }) {
+    const posts = getCategoryPosts('cpat');
+
+    const pageIndex = parseInt(params.page) - 1;
+    const startIndex = pageIndex * config.postsPerPage;
+    const endIndex = (pageIndex + 1) * config.postsPerPage;
+
+    const prevPosts = (pageIndex > 0) ? pageIndex : null;
+    const nextPosts = (endIndex >= posts.length) ? null : (pageIndex + 2);
+    const numPages  = (config.postsPerPage % getCategoryPosts('cpat').length) + 1;
+
+    return {
+        props: {
+            posts: posts.slice(startIndex, endIndex),
+            prevPosts,
+            nextPosts,
+            pageIndex,
+            numPages
+        }
+    }
+};
+
+/**
+ * 
+ */
+export async function getStaticPaths() {
+    const numPages = (config.postsPerPage % getCategoryPosts('cpat').length) + 1;
+
+    return {
+        paths: [...Array(numPages)].map( (v, i) => {
+            return {
+                params: { page: (i + 1).toString() }
+            }
+        }),
+        fallback: false
+    }
+};
+
+
+const CpatCategory = ({ posts, prevPosts, nextPosts }) => {
+    return (
+        <Layout home>
+            <section className={`${utilStyles.headingMd} ${utilStyles.padding1px}`}>
+                <h2 className={utilStyles.headingLg}>Blog</h2>
+                <ul className={utilStyles.list}>
+                    {posts.map( ({ id, date, title }) => (
+                        <li className={utilStyles.listItem} key={id}>
+                            <Link href={`/blog/${id}`}>
+                                <a>{title}</a>
+                            </Link>
+                            <br />
+                            <small className={utilStyles.lightText}>
+                                <Date dateString={date} />
+                            </small>
+                        </li>
+                    ))}
+                </ul>
+
+                {prevPosts !== null && (
+                    <Link href={"/categories/cpat/pages/" + prevPosts} passHref>
+                        <a>« see newer posts</a>
+                    </Link>
+                )}
+                {nextPosts !== null && (
+                    <Link href={"/categories/cpat/pages/" + nextPosts} passHref>
+                    <a>see older posts »</a>
+                    </Link>
+                )}
+            </section>
+        </Layout>
+    );
+};
+
+export default CpatCategory;

--- a/posts/test-post_cpat_12.md
+++ b/posts/test-post_cpat_12.md
@@ -1,0 +1,20 @@
+---
+title: 'Test Post - cpat - 12'
+date: '2020-01-02'
+section: 'cpat'
+---
+
+We recommend using **Static Generation** (with and without data) whenever possible because your page can be built once and served by CDN, which makes it much faster than having a server render the page on every request.
+
+You can use Static Generation for many types of pages, including:
+
+- Marketing pages
+- Blog posts
+- E-commerce product listings
+- Help and documentation
+
+You should ask yourself: "Can I pre-render this page **ahead** of a user's request?" If the answer is yes, then you should choose Static Generation.
+
+On the other hand, Static Generation is **not** a good idea if you cannot pre-render a page ahead of a user's request. Maybe your page shows frequently updated data, and the page content changes on every request.
+
+In that case, you can use **Server-Side Rendering**. It will be slower, but the pre-rendered page will always be up-to-date. Or you can skip pre-rendering and use client-side JavaScript to populate data.

--- a/posts/test-post_cpat_13.md
+++ b/posts/test-post_cpat_13.md
@@ -1,0 +1,20 @@
+---
+title: 'Test Post - cpat - 13'
+date: '2020-01-02'
+section: 'cpat'
+---
+
+We recommend using **Static Generation** (with and without data) whenever possible because your page can be built once and served by CDN, which makes it much faster than having a server render the page on every request.
+
+You can use Static Generation for many types of pages, including:
+
+- Marketing pages
+- Blog posts
+- E-commerce product listings
+- Help and documentation
+
+You should ask yourself: "Can I pre-render this page **ahead** of a user's request?" If the answer is yes, then you should choose Static Generation.
+
+On the other hand, Static Generation is **not** a good idea if you cannot pre-render a page ahead of a user's request. Maybe your page shows frequently updated data, and the page content changes on every request.
+
+In that case, you can use **Server-Side Rendering**. It will be slower, but the pre-rendered page will always be up-to-date. Or you can skip pre-rendering and use client-side JavaScript to populate data.

--- a/posts/test-post_cpat_14.md
+++ b/posts/test-post_cpat_14.md
@@ -1,0 +1,20 @@
+---
+title: 'Test Post - cpat - 14'
+date: '2020-01-02'
+section: 'cpat'
+---
+
+We recommend using **Static Generation** (with and without data) whenever possible because your page can be built once and served by CDN, which makes it much faster than having a server render the page on every request.
+
+You can use Static Generation for many types of pages, including:
+
+- Marketing pages
+- Blog posts
+- E-commerce product listings
+- Help and documentation
+
+You should ask yourself: "Can I pre-render this page **ahead** of a user's request?" If the answer is yes, then you should choose Static Generation.
+
+On the other hand, Static Generation is **not** a good idea if you cannot pre-render a page ahead of a user's request. Maybe your page shows frequently updated data, and the page content changes on every request.
+
+In that case, you can use **Server-Side Rendering**. It will be slower, but the pre-rendered page will always be up-to-date. Or you can skip pre-rendering and use client-side JavaScript to populate data.

--- a/posts/test-post_cpat_15.md
+++ b/posts/test-post_cpat_15.md
@@ -1,0 +1,20 @@
+---
+title: 'Test Post - cpat - 15'
+date: '2020-01-02'
+section: 'cpat'
+---
+
+We recommend using **Static Generation** (with and without data) whenever possible because your page can be built once and served by CDN, which makes it much faster than having a server render the page on every request.
+
+You can use Static Generation for many types of pages, including:
+
+- Marketing pages
+- Blog posts
+- E-commerce product listings
+- Help and documentation
+
+You should ask yourself: "Can I pre-render this page **ahead** of a user's request?" If the answer is yes, then you should choose Static Generation.
+
+On the other hand, Static Generation is **not** a good idea if you cannot pre-render a page ahead of a user's request. Maybe your page shows frequently updated data, and the page content changes on every request.
+
+In that case, you can use **Server-Side Rendering**. It will be slower, but the pre-rendered page will always be up-to-date. Or you can skip pre-rendering and use client-side JavaScript to populate data.

--- a/posts/test-post_cpat_16.md
+++ b/posts/test-post_cpat_16.md
@@ -1,0 +1,20 @@
+---
+title: 'Test Post - cpat - 16'
+date: '2020-01-02'
+section: 'cpat'
+---
+
+We recommend using **Static Generation** (with and without data) whenever possible because your page can be built once and served by CDN, which makes it much faster than having a server render the page on every request.
+
+You can use Static Generation for many types of pages, including:
+
+- Marketing pages
+- Blog posts
+- E-commerce product listings
+- Help and documentation
+
+You should ask yourself: "Can I pre-render this page **ahead** of a user's request?" If the answer is yes, then you should choose Static Generation.
+
+On the other hand, Static Generation is **not** a good idea if you cannot pre-render a page ahead of a user's request. Maybe your page shows frequently updated data, and the page content changes on every request.
+
+In that case, you can use **Server-Side Rendering**. It will be slower, but the pre-rendered page will always be up-to-date. Or you can skip pre-rendering and use client-side JavaScript to populate data.


### PR DESCRIPTION
- Created to /categories/cpat/index.js as landing "page" for this category. Basic paging support was almost copy/paste
- Added /categories/cpat/pages/[page].js as a route to move between pages in the category. Again, almost copy/paste from the mainline paging support.
- Added a bunch of test data posts to see the paging in action