### PR TITLE
Responsive changes, tested for iOS 12

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -28,39 +28,21 @@ export default function Layout({ children, home }) {
           <link href="https://fonts.googleapis.com/css2?family=Palanquin+Dark:wght@400;700&family=Palanquin:wght@100;300&display=swap" rel="stylesheet"></link>
         </Head>
 
-          {home ? (
-            <header className={styles.header}>
-              <h1 className={utilStyles.heading2Xl}>
-                <Link href="/">
-                  <a className={utilStyles.colorInherit}>{name}</a>
-                </Link>
-              </h1>
+        <header className={styles.header}>
+          <h1 className={utilStyles.heading2Xl}>
+            <Link href="/">
+              <a className={utilStyles.colorInherit}>{name}</a>
+            </Link>
+          </h1>
 
-              <div className={styles.navbarLinks}>
-                <h2>
-                  <Link href="/about">
-                    <a className={utilStyles.colorInherit}>About</a>
-                  </Link>
-                </h2>
-              </div>
-            </header>
-          ) : (
-            <header className={styles.header}>
-              <h1 className={utilStyles.heading2Xl}>
-                <Link href="/">
-                  <a className={utilStyles.colorInherit}>{name}</a>
-                </Link>
-              </h1>
-
-              <div className={styles.navbarLinks}>
-                <h2>
-                  <Link href="/about">
-                    <a className={utilStyles.colorInherit}>About</a>
-                  </Link>
-                </h2>
-              </div>
-            </header>
-          )}
+          <div className={styles.navbarLinks}>
+            <h2>
+              <Link href="/about">
+                <a className={utilStyles.colorInherit}>About</a>
+              </Link>
+            </h2>
+          </div>
+        </header>
 
         <div className={styles.container}>
           {children}

--- a/components/layout.module.css
+++ b/components/layout.module.css
@@ -3,6 +3,13 @@
     justify-content: center;
     margin: 0 25% 0 25%;
 }
+@media (max-width: 399px),
+    screen and (orientation: portrait) {
+        .container {
+            margin: 0 7% 0 7%;
+        }
+    }
+
 @media (min-width: 400px), screen and (orientation: portrait) {
     .container {
         margin: 0 7% 0 7%;
@@ -25,7 +32,6 @@
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
-    /* margin: 0.5em 1em; */
 
     font-weight: 400;
     font-family: 'Palanquin Dark', sans-serif;

--- a/pages/blog/pages/[page].js
+++ b/pages/blog/pages/[page].js
@@ -55,56 +55,54 @@ export async function getStaticPaths() {
 
 const PostsPage = ({ posts, categoriesList, prevPosts, nextPosts }) => {
     return (
-        
-            <Layout home>
-                <div className={`${utilStyles.horizontal}`}>
-                    <section className={`${utilStyles.headingMd} ${utilStyles.padding1px} ${utilStyles.categoriesSection}`}>
-                        <h2 className={utilStyles.headingLg}>Categories</h2>
-                        <ul>
-                            {categoriesList.map((section) => {
-                                return (
-                                    <li key={section}>
-                                        <Link href={`/categories/${section}`}>
-                                            {section}
-                                        </Link>
-                                    </li>
-                                );
-                            })}
-                        </ul>
-                    </section>
-
-                    <section className={`${utilStyles.headingMd} ${utilStyles.padding1px} ${utilStyles.postsSection}`}>
-                        <h2 className={utilStyles.headingLg}>Blog</h2>
-                        <ul className={utilStyles.list}>
-                            {posts.map( ({ id, date, title }) => (
-                                <li className={utilStyles.listItem} key={id}>
-                                    <Link href={`/blog/${id}`}>
-                                        <a>{title}</a>
+        <Layout home>
+            <div className={`${utilStyles.horizontal}`}>
+                <section className={`${utilStyles.headingMd} ${utilStyles.padding1px} ${utilStyles.categoriesSection}`}>
+                    <h2 className={utilStyles.headingLg}>Categories</h2>
+                    <ul>
+                        {categoriesList.map((section) => {
+                            return (
+                                <li key={section}>
+                                    <Link href={`/categories/${section}`}>
+                                        {section}
                                     </Link>
-                                    <br />
-                                    <small className={utilStyles.lightText}>
-                                        <Date dateString={date} />
-                                    </small>
                                 </li>
-                            ))}
-                        </ul>
+                            );
+                        })}
+                    </ul>
+                </section>
 
-                        <section className={`${utilStyles.centeredButtons}`}>
-                            {prevPosts !== null && (
-                                <Link href={"/blog/pages/" + prevPosts} passHref>
-                                    <a>« newer</a>
+                <section className={`${utilStyles.headingMd} ${utilStyles.padding1px} ${utilStyles.postsSection}`}>
+                    <h2 className={utilStyles.headingLg}>Blog</h2>
+                    <ul className={utilStyles.list}>
+                        {posts.map( ({ id, date, title }) => (
+                            <li className={utilStyles.listItem} key={id}>
+                                <Link href={`/blog/${id}`}>
+                                    <a>{title}</a>
                                 </Link>
-                            )}
-                            {nextPosts !== null && (
-                                <Link href={"/blog/pages/" + nextPosts} passHref>
-                                <a>older »</a>
-                                </Link>
-                            )}
-                        </section>
+                                <br />
+                                <small className={utilStyles.lightText}>
+                                    <Date dateString={date} />
+                                </small>
+                            </li>
+                        ))}
+                    </ul>
+
+                    <section className={`${utilStyles.centeredButtons}`}>
+                        {prevPosts !== null && (
+                            <Link href={"/blog/pages/" + prevPosts} passHref>
+                                <a>« newer</a>
+                            </Link>
+                        )}
+                        {nextPosts !== null && (
+                            <Link href={"/blog/pages/" + nextPosts} passHref>
+                            <a>older »</a>
+                            </Link>
+                        )}
                     </section>
-                </div>
-            </Layout>
-        
+                </section>
+            </div>
+        </Layout>
     );
 };
 

--- a/styles/about.module.css
+++ b/styles/about.module.css
@@ -5,37 +5,38 @@
     width: 60%;
 }
 
-/* If screen is 400px or wider */
-@media (min-width: 400px), screen and (orientation: portrait) {
+/* If screen is 1920px or wider */
+@media (min-width: 1920px) {
     .mainContent {
-        width: 90%;
-    }
-}
-
-/* If screen is 700px or wider */
-@media (min-width: 700px), screen and (orientation: portrait) {
-    .mainContent {
-        width: 80%;
+        width: 30%;
     }
 }
 
 /* If screen is 1000px or wider */
-@media (min-width: 1000px), screen and (orientation: portrait) {
-    .mainContent {
-        width: 70%;
-    }
-}
-
-/* If screen is 1000px or wider */
-@media (min-width: 1300px), screen and (orientation: portrait) {
+@media (min-width: 1300px) and (max-width: 1919px) {
     .mainContent {
         width: 50%;
     }
 }
 
-/* If screen is 1920px or wider */
-@media (min-width: 1920px), screen and (orientation: portrait) {
+/* If screen is 700px or wider */
+@media (min-width: 700px) and (max-width: 1299px),
+    screen and (orientation: portrait) {
     .mainContent {
-        width: 30%;
+        width: 80%;
+    }
+}
+
+/* If screen is 400px or wider */
+@media (min-width: 400px) and (max-width: 699px), 
+    screen and (orientation: portrait) {
+    .mainContent {
+        width: 90%;
+    }
+}
+
+@media (max-width: 399px) {
+    .mainContent {
+        width: 100%;
     }
 }

--- a/styles/global.css
+++ b/styles/global.css
@@ -27,7 +27,7 @@ img {
 }
 
 
-@media (min-width: 400px), screen and (orientation: portrait) {
+@media (min-width: 400px) {
   .remark-highlight {
     font-size: 16px;
   }

--- a/styles/utils.module.css
+++ b/styles/utils.module.css
@@ -5,10 +5,15 @@
     letter-spacing: -0.05rem;
     margin: 1rem 0;
 }
-@media (min-width: 400px), screen and (orientation: portrait) {
-  .heading2Xl {
-      font-size: 2rem;
-  }
+
+.categoriesSection {
+  font-size: 1rem;
+  margin-right: 10em;
+  margin-top: 3em;
+}
+
+.postsSection {
+  min-width: 35rem;
 }
   
   .headingXl {
@@ -57,6 +62,7 @@
   }
   
 
+
   .horizontal {
     display: flex;
     justify-content: space-between;
@@ -71,18 +77,45 @@
     margin: 0;
   }
 
-.categoriesSection {
-  font-size: 1rem;
-  margin-right: 10em;
-  margin-top: 3em;
-}
-
-.postsSection {
-  min-width: 35rem;
-}
 
 .centeredButtons {
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+
+
+@media (min-width: 400px) and (max-width: 699px), 
+screen and (orientation: portrait) {
+  .heading2Xl {
+      font-size: 1.8rem;
+  }
+
+  .postsSection {
+    min-width: 5rem;
+    font-size: 1.1em;
+  }
+
+  .categoriesSection {
+    display: none;
+  }
+}
+
+/* If screen is 700px or wider */
+@media (min-width: 700px) and (max-width: 1299px),
+    screen and (orientation: portrait) {
+      .heading2Xl {
+        font-size: 1.8rem;
+    }
+  
+    .postsSection {
+      min-width: 5rem;
+      font-size: 1.1em;
+    }
+  
+    .categoriesSection {
+      margin-right: 5em;
+      font-size: 1em;
+      margin-top: 0;
+    }
 }


### PR DESCRIPTION
- New media queries, and moved to bottom, for utils.module.css (main fix)
- Layout header no longer has "home" style--just one type of header for every page
- Separate screen width breaks introduced to About page styles
- Indenting fixed on /blog/pages/[page].js