### PR TITLE
Feature/responsive header

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -2,6 +2,7 @@ import Head from 'next/head';
 import styles from './layout.module.css';
 import utilStyles from '../styles/utils.module.css';
 import Link from 'next/link';
+import MenuIcon from './menu-icon';
 
 const name = 'Rushing Labs';
 export const siteTitle = 'Rushing Labs';
@@ -29,6 +30,8 @@ export default function Layout({ children, home }) {
         </Head>
 
         <header className={styles.header}>
+          <MenuIcon />
+
           <h1 className={utilStyles.heading2Xl}>
             <Link href="/">
               <a className={utilStyles.colorInherit}>{name}</a>

--- a/components/layout.module.css
+++ b/components/layout.module.css
@@ -3,18 +3,46 @@
     justify-content: center;
     margin: 0 25% 0 25%;
 }
-@media (max-width: 399px),
-    screen and (orientation: portrait) {
+
+
+
+/*
+ * Mobile view media queries
+*/
+@media only screen and (max-width: 399px) {
         .container {
             margin: 0 7% 0 7%;
         }
+
+        .navbarLinks > h2 {
+            display: none;
+        }
     }
 
-@media (min-width: 400px), screen and (orientation: portrait) {
+
+@media only screen and (max-width: 450px) {
     .container {
         margin: 0 7% 0 7%;
     }
+
+    .navbarLinks > h2 {
+        display: none;
+    }
 }
+
+@media only screen, (orientation: portrait) and (min-width: 768px) {
+    .container {
+        margin: 0 7% 0 7%;
+    }
+
+    /* .navbarLinks > h2 {
+        display: none;
+    } */
+}
+
+
+
+
 /*
 * keeps the article content from overflowing the margins
 * (especially when very wide, code snippets are being converted into <pre> blocks in Markdown)
@@ -37,9 +65,8 @@
     font-family: 'Palanquin Dark', sans-serif;
 }
 
-.header > div {
+.header > .navbarLinks {
     margin: 0;
-
     display: flex;
 }
 

--- a/components/menu-icon.js
+++ b/components/menu-icon.js
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+import Link from 'next/link';
+import styles from './menu-icon.module.css';
+import utilStyles from '../styles/utils.module.css';
+
+export default function MenuIcon() {
+    const [toggleOpen, setToggleOpen] = useState();
+
+    const handleToggle = () => {
+        setToggleOpen(!toggleOpen);
+    };
+
+    return (
+        <div className={styles.menuIcon} onClick={handleToggle}>
+            {/* <div className={styles.barsContainer}> */}
+                <div></div>
+                <div></div>
+                <div></div>
+            {/* </div> */}
+
+            {toggleOpen ? (
+                <ul className={styles.list}>
+                    <li className={styles.listItem}>
+                        <Link href="/projects">
+                            <a className={utilStyles.colorInherit}>Projects</a>
+                        </Link>
+                    </li>
+                    <li className={styles.listItem}>
+                        <Link href="/about">
+                            <a className={utilStyles.colorInherit}>About</a>
+                        </Link>
+                    </li>
+                </ul>) : ''}
+        </div>
+    );
+}

--- a/components/menu-icon.module.css
+++ b/components/menu-icon.module.css
@@ -1,0 +1,53 @@
+.menuIcon {
+    cursor: pointer;
+    flex-direction: column;
+}
+
+.list {
+    list-style: none;
+    margin: 0px;
+    padding: 0px;
+    position: fixed;
+    z-index: 9;
+    width: 100%;
+    overflow: hidden;
+    max-width: 290px;
+    color: black;
+    top: 0;
+    left: 0;
+    bottom: 0;
+}
+
+.listItem {
+    background: lightgray;
+    padding: 10px 40px;
+}
+.listItem:first-child {
+    margin-top: 5rem;
+}
+
+@media (max-width: 399px),
+    screen and (orientation: portrait) {
+        .menuIcon > div {
+            width: 35px;
+            height: 5px;
+            background-color: whitesmoke;
+            margin: 6px 0;
+        }
+}
+
+@media (min-width: 400px), 
+    screen and (orientation: portrait) {
+        .menuIcon > div {
+            width: 35px;
+            height: 5px;
+            background-color: whitesmoke;
+            margin: 6px 0;
+        }
+}
+
+@media only screen and (min-width: 1200px) {
+    .menuIcon {
+        display: none;
+    }
+}

--- a/pages/blog/pages/[page].js
+++ b/pages/blog/pages/[page].js
@@ -73,7 +73,6 @@ const PostsPage = ({ posts, categoriesList, prevPosts, nextPosts }) => {
                 </section>
 
                 <section className={`${utilStyles.headingMd} ${utilStyles.padding1px} ${utilStyles.postsSection}`}>
-                    <h2 className={utilStyles.headingLg}>Blog</h2>
                     <ul className={utilStyles.list}>
                         {posts.map( ({ id, date, title }) => (
                             <li className={utilStyles.listItem} key={id}>


### PR DESCRIPTION
Resolves issue #29 

We now have a responsive header for mobile screens. Responsiveness still needs to be expanded out to other pages, and more screen sizes, but this is good for now.

## New header w/ menu icon

![image](https://user-images.githubusercontent.com/8764066/136153411-6d2afedc-55b4-483f-9c9d-59fcd707d2db.png)

![image](https://user-images.githubusercontent.com/8764066/136153512-efd0fb50-7e17-4d1d-adff-5425dc5239cd.png)

